### PR TITLE
Add a CPU pool to environment.

### DIFF
--- a/src/rigging/Cargo.toml
+++ b/src/rigging/Cargo.toml
@@ -7,14 +7,17 @@ version = "0.1.0"
 anymap = "0.12.1"
 backtrace = "0.3.0"
 futures = "0.1.13"
+futures-cpupool = "0.1.5"
+num_cpus = "1.5.1"
+r2d2 = "0.7.2"
 route-recognizer = "0.1.12"
 serde = "1.0.0"
 tokio-core = "0.1.6"
 url = "1.4.0"
 
 [dependencies.c3po]
-git = "https://github.com/withoutboats/c3po"
 branch = "singlethreaded"
+git = "https://github.com/withoutboats/c3po"
 
 [dependencies.hyper]
 branch = "new-new-service"

--- a/src/rigging/src/lib.rs
+++ b/src/rigging/src/lib.rs
@@ -3,10 +3,13 @@
 extern crate anymap;
 extern crate backtrace;
 extern crate futures;
+extern crate futures_cpupool;
 extern crate hyper;
 extern crate tokio_service as tokio;
 extern crate tokio_core as core;
 extern crate c3po;
+extern crate r2d2;
+extern crate num_cpus;
 extern crate route_recognizer as recognizer;
 extern crate serde;
 extern crate tokio_redis as redis;


### PR DESCRIPTION
This adds two methods:

* `on_pool`, which allows you to run a closure on the CPU pool.
* `sync_conn`, which allows you to access a synchronous connection,
managed by r2d2 (it is not possible to set up such a connection yet;
more coming!).

The CPU pool has 4 * the number of CPU threads. Someday this number
will be configurable.