### PR TITLE
Print address the server is running on

### DIFF
--- a/src/rigging/src/http.rs
+++ b/src/rigging/src/http.rs
@@ -36,6 +36,7 @@ where
             })
         })
     });
+    println!("Running on {}", addr);
     core.run(srv)
 }
 


### PR DESCRIPTION
This PR is a one line change that prints out `Running on 127.0.0.1:7878` or whatever address it is running on.

When trying out cargonauts I was confused about which port it was running on, so I thought it might be useful to print it out. 